### PR TITLE
Make Snapshot and EventStream Enumerable

### DIFF
--- a/lib/event_store/aggregate.rb
+++ b/lib/event_store/aggregate.rb
@@ -4,21 +4,19 @@ module EventStore
   class Aggregate
     extend Forwardable
 
-    attr_reader :id, :type, :event_table
+    attr_reader :id, :type, :event_table, :snapshot, :event_stream
 
-    def_delegators :@snapshot,
+    def_delegators :snapshot,
       :last_event,
-      :snapshot,
       :rebuild_snapshot!,
       :delete_snapshot!,
       :version,
       :version_for,
       :snapshot_version_table
 
-    def_delegators :@event_stream,
+    def_delegators :event_stream,
       :events,
       :events_from,
-      :event_stream,
       :event_stream_between,
       :event_table,
       :delete_events!
@@ -44,8 +42,8 @@ module EventStore
     end
 
     def append(events)
-      @event_stream.append(events) do |prepared_events|
-        @snapshot.store_snapshot(prepared_events)
+      event_stream.append(events) do |prepared_events|
+        snapshot.store_snapshot(prepared_events)
       end
     end
 

--- a/lib/event_store/client.rb
+++ b/lib/event_store/client.rb
@@ -2,7 +2,17 @@ module EventStore
   class Client
     extend Forwardable
 
-    def_delegators :aggregate, :delete_snapshot!, :snapshot_version_table, :version_for
+    def_delegators :aggregate,
+                   :delete_snapshot!,
+                   :snapshot_version_table,
+                   :version_for,
+                   :event_table,
+                   :type,
+                   :id,
+                   :version
+
+    def_delegators :event_stream,
+                   :count
 
     def self.count
       Aggregate.count
@@ -18,18 +28,6 @@ module EventStore
 
     def exists?
       aggregate.snapshot_exists?
-    end
-
-    def id
-      aggregate.id
-    end
-
-    def type
-      aggregate.type
-    end
-
-    def event_table
-      aggregate.event_table
     end
 
     def append(event_data)
@@ -68,14 +66,6 @@ module EventStore
 
     def raw_event_stream_from version_number, max=nil
       aggregate.events_from(version_number, max)
-    end
-
-    def version
-      aggregate.version
-    end
-
-    def count
-      event_stream.length
     end
 
     def destroy!

--- a/lib/event_store/event_stream.rb
+++ b/lib/event_store/event_stream.rb
@@ -1,5 +1,6 @@
 module EventStore
   class EventStream
+    include Enumerable
 
     attr_reader :event_table
 
@@ -43,8 +44,19 @@ module EventStore
       query.all.map {|e| e[:serialized_event] = EventStore.unescape_bytea(e[:serialized_event]); e}
     end
 
-    def event_stream
-      events.all.map {|e| e[:serialized_event] = EventStore.unescape_bytea(e[:serialized_event]); e}
+    def last
+      to_a.last
+    end
+
+    def empty?
+      events.empty?
+    end
+
+    def each
+      events.all.each do |e|
+        e[:serialized_event] = EventStore.unescape_bytea(e[:serialized_event])
+        yield e
+      end
     end
 
     def delete_events!

--- a/spec/event_store/client_spec.rb
+++ b/spec/event_store/client_spec.rb
@@ -49,7 +49,6 @@ describe EventStore::Client do
   describe '#raw_event_stream' do
     it "should be an array of hashes that represent database records, not EventStore::SerializedEvent objects" do
       raw_stream = es_client.new(AGGREGATE_ID_ONE, :device).raw_event_stream
-      expect(raw_stream.class).to eq(Array)
       raw_event = raw_stream.first
       expect(raw_event.class).to eq(Hash)
       expect(raw_event.keys).to eq([:id, :version, :aggregate_id, :fully_qualified_name, :occurred_at, :serialized_event, :sub_key])
@@ -288,16 +287,16 @@ describe EventStore::Client do
         it "should set the snapshot version number to match that of the last event in the aggregate's event stream" do
           events = [@new_event, @really_new_event]
           initial_stream_version = @client.raw_event_stream.last[:version]
-          expect(@client.snapshot.last.version).to eq(initial_stream_version)
+          expect(@client.snapshot.version).to eq(initial_stream_version)
           @client.append(events)
           updated_stream_version = @client.raw_event_stream.last[:version]
-          expect(@client.snapshot.last.version).to eq(updated_stream_version)
+          expect(@client.snapshot.version).to eq(updated_stream_version)
         end
 
         it "should write-through-cache the event in a snapshot without duplicating events" do
           @client.destroy!
           @client.append([@old_event, @new_event, @really_new_event])
-          expect(@client.snapshot).to eq(@client.event_stream)
+          expect(@client.snapshot.to_a).to eq(@client.event_stream)
         end
 
         it "should raise a meaningful exception when a nil event given to it to append" do
@@ -323,7 +322,7 @@ describe EventStore::Client do
           expected =  []
           expected << @client.event_stream.first
           expected << @client.event_stream.last
-          expect(@client.snapshot).to eq(expected)
+          expect(@client.snapshot.to_a).to eq(expected)
         end
 
         #TODO if we let the db assign version# then this can't be true anymore
@@ -341,10 +340,10 @@ describe EventStore::Client do
         it "should set the snapshot version number to match that of the last event in the aggregate's event stream" do
           events = [@old_event, @old_event]
           initial_stream_version = @client.raw_event_stream.last[:version]
-          expect(@client.snapshot.last.version).to eq(initial_stream_version)
+          expect(@client.snapshot.version).to eq(initial_stream_version)
           @client.append(events)
           updated_stream_version = @client.raw_event_stream.last[:version]
-          expect(@client.snapshot.last.version).to eq(updated_stream_version)
+          expect(@client.snapshot.version).to eq(updated_stream_version)
         end
       end
     end

--- a/spec/event_store/snapshot_spec.rb
+++ b/spec/event_store/snapshot_spec.rb
@@ -6,12 +6,11 @@ AGGREGATE_ID_TWO = SecureRandom.uuid
 
 module EventStore
   describe "Snapshots" do
-
     context "when there are no events" do
       let(:client)    { EventStore::Client.new(AGGREGATE_ID_ONE) }
 
       it "should build an empty snapshot for a new client" do
-        expect(client.snapshot).to eq([])
+        expect(client.snapshot.any?).to eq(false)
         expect(client.version).to eq(-1)
         expect(EventStore.redis.hget(client.snapshot_version_table, :current_version)).to eq(nil)
       end
@@ -27,7 +26,7 @@ module EventStore
       let(:client)    { EventStore::Client.new(AGGREGATE_ID_TWO) }
 
       before do
-        expect(client.snapshot.length).to eq(0)
+        expect(client.snapshot.count).to eq(0)
         client.append events_for(AGGREGATE_ID_TWO)
       end
 
@@ -49,14 +48,14 @@ module EventStore
         expected_snapshot = serialized_events(expected_snapshot_events)
         actual_snapshot = client.snapshot
 
-        expect(client.event_stream.length).to eq(15)
+        expect(client.event_stream.count).to eq(15)
         expect(actual_snapshot.map(&:fully_qualified_name)).to eq(expected_snapshot_events)
-        expect(actual_snapshot.length).to eq(8)
+        expect(actual_snapshot.count).to eq(8)
         expect(actual_snapshot.map(&:serialized_event)).to eq(expected_snapshot.map(&:serialized_event))
       end
 
       it "increments the version number of the snapshot when an event is appended" do
-        expect(client.snapshot.last.version).to eq(client.raw_event_stream.last[:version])
+        expect(client.snapshot.version).to eq(client.raw_event_stream.last[:version])
       end
     end
 


### PR DESCRIPTION
This PR converts `EventStore::Snapshot` and `EventStore::EventStream` into being `Enumerable`s. This has a few advantages:

* You don't need to call `Snapshot#snapshot` anymore (seriously, what does that mean?)
* `Aggregator` and `Client` don't need to define `#event_stream` and `#snapshot` methods that return arrays; we can just return the objects themselves, and let the clients iterate over them normally.

Faceplate, Proxy, and Diagnostics (neé Dealer) all build cleanly with this change.