### PR TITLE
[#98224100] rebuild snapshot from last checkpoint

### DIFF
--- a/lib/event_store/aggregate.rb
+++ b/lib/event_store/aggregate.rb
@@ -4,7 +4,7 @@ module EventStore
   class Aggregate
     extend Forwardable
 
-    attr_reader :id, :type, :event_table, :snapshot, :event_stream
+    attr_reader :id, :type, :event_table, :snapshot, :event_stream, :checkpoint_event
 
     def_delegators :snapshot,
       :last_event,
@@ -16,6 +16,7 @@ module EventStore
 
     def_delegators :event_stream,
       :events,
+      :snapshot_events,
       :events_from,
       :event_stream_between,
       :event_table,
@@ -34,12 +35,13 @@ module EventStore
       EventStore.db.from( EventStore.fully_qualified_table).distinct(:aggregate_id).select(:aggregate_id).order(:aggregate_id).limit(limit, offset).all.map{|item| item[:aggregate_id]}
     end
 
-    def initialize(id, type = EventStore.table_name)
+    def initialize(id, type = EventStore.table_name, checkpoint_event = nil)
       @id = id
       @type = type
 
-      @snapshot     = Snapshot.new(self)
-      @event_stream = EventStream.new(self)
+      @checkpoint_event = checkpoint_event
+      @snapshot         = Snapshot.new(self)
+      @event_stream     = EventStream.new(self)
     end
 
     def append(events, logger)

--- a/lib/event_store/client.rb
+++ b/lib/event_store/client.rb
@@ -22,8 +22,8 @@ module EventStore
       Aggregate.ids(offset, limit)
     end
 
-    def initialize(aggregate_id, aggregate_type = EventStore.table_name)
-      @aggregate = Aggregate.new(aggregate_id, aggregate_type)
+    def initialize(aggregate_id, aggregate_type = EventStore.table_name, checkpoint_event = nil)
+      @aggregate = Aggregate.new(aggregate_id, aggregate_type, checkpoint_event)
     end
 
     def exists?

--- a/lib/event_store/snapshot.rb
+++ b/lib/event_store/snapshot.rb
@@ -58,7 +58,8 @@ module EventStore
       delete_snapshot!
       logger.debug { "Deleting snapshot took #{Time.now - t} seconds" }
       t = Time.now
-      all_events = @aggregate.events.all
+      all_events = @aggregate.snapshot_events.all
+      logger.debug { "getting #{all_events.count} events" }
       logger.debug { "getting all events took #{Time.now - t} seconds" }
       t = Time.now
       corrected_events = all_events.map{|e| e[:occurred_at] = TimeHacker.translate_occurred_at_from_local_to_gmt(e[:occurred_at]); e}

--- a/lib/event_store/version.rb
+++ b/lib/event_store/version.rb
@@ -1,3 +1,3 @@
 module EventStore
-  VERSION = '0.7.4'
+  VERSION = '0.7.5'
 end


### PR DESCRIPTION
* checkpoint fqn is passed in from consumer
* this commit assumes that a checkpoint is a fresh start
  and that rebuilding a snapshot from that point is
  completely valid
* this will prevent the replay of non-meaningful events
  that occurred before the checkpoint