### PR TITLE
[#97661804] enable event_store to be partitioned

### DIFF
--- a/lib/event_store.rb
+++ b/lib/event_store.rb
@@ -68,11 +68,11 @@ module EventStore
   end
 
   def self.partitioning?
-    raw_db_config["partitioning"]
+    @db_config["partitioning"]
   end
 
   def self.table_name_suffix
-    raw_db_config["table_name_suffix"]
+    @db_config["table_name_suffix"]
   end
 
   def self.table_name

--- a/lib/event_store.rb
+++ b/lib/event_store.rb
@@ -60,6 +60,21 @@ module EventStore
     @schema ||= raw_db_config[@environment][@adapter]['schema']
   end
 
+  def self.insert_table_name(date)
+    return fully_qualified_table unless partitioning?
+
+    partition_name = date.strftime("#{table_name}#{table_name_suffix}")
+    qualified_table_name(partition_name)
+  end
+
+  def self.partitioning?
+    raw_db_config["partitioning"]
+  end
+
+  def self.table_name_suffix
+    raw_db_config["table_name_suffix"]
+  end
+
   def self.table_name
     @table_name ||= raw_db_config['table_name']
   end
@@ -69,7 +84,11 @@ module EventStore
   end
 
   def self.fully_qualified_table
-    @fully_qualified_table ||= Sequel.lit "#{schema}.#{table_name}"
+    @fully_qualified_table ||= qualified_table_name
+  end
+
+  def self.qualified_table_name(name = table_name)
+    Sequel.lit "#{schema}.#{name}"
   end
 
   def self.fully_qualified_names_table

--- a/lib/event_store.rb
+++ b/lib/event_store.rb
@@ -63,7 +63,7 @@ module EventStore
   def self.insert_table_name(date)
     return fully_qualified_table unless partitioning?
 
-    partition_name = date.strftime("#{table_name}#{table_name_suffix}")
+    partition_name = date.strftime("#{table_name}#{partition_name_suffix}")
     qualified_table_name(partition_name)
   end
 
@@ -71,8 +71,8 @@ module EventStore
     @db_config["partitioning"]
   end
 
-  def self.table_name_suffix
-    @db_config["table_name_suffix"]
+  def self.partition_name_suffix
+    @db_config["partition_name_suffix"]
   end
 
   def self.table_name

--- a/lib/event_store/event_stream.rb
+++ b/lib/event_store/event_stream.rb
@@ -21,9 +21,9 @@ module EventStore
         event
       end
 
-      event_table = EventStore.db.from(@event_table)
       prepared_events.each do |event|
         event_hash = event.dup.reject! { |k,v| k == :fully_qualified_name }
+        event_table = insert_table(event_hash[:occurred_at])
 
         begin
           id = event_table.insert(event_hash)
@@ -38,6 +38,14 @@ module EventStore
       end
 
       yield(prepared_events) if block_given?
+    end
+
+    def insert_table(occurred_at)
+      EventStore.db.from(insert_table_name(occurred_at))
+    end
+
+    def insert_table_name(date)
+      EventStore.insert_table_name(date)
     end
 
     def fully_qualified_names

--- a/lib/event_store/version.rb
+++ b/lib/event_store/version.rb
@@ -1,3 +1,3 @@
 module EventStore
-  VERSION = '0.7.5'
+  VERSION = '0.8.0'
 end

--- a/spec/event_store/client_spec.rb
+++ b/spec/event_store/client_spec.rb
@@ -267,21 +267,21 @@ describe EventStore::Client do
             client.append([old_event])
           end
 
-          it "should append a single event of a new type without raising an error" do
+          it "appends a single event of a new type without raising an error" do
             initial_count = client.count
             events = [new_event]
             client.append(events)
             expect(client.count).to eq(initial_count + events.length)
           end
 
-          it "should append multiple events of a new type without raising and error" do
+          it "appends multiple events of a new type without raising and error" do
             initial_count = client.count
             events = [new_event, new_event]
             client.append(events)
             expect(client.count).to eq(initial_count + events.length)
           end
 
-          it "should change the event id number" do
+          it "changes the event id number" do
             events = [new_event, really_new_event]
             expect{ client.append(events) }.to change(client, :event_id)
           end
@@ -293,7 +293,7 @@ describe EventStore::Client do
             expect(client.snapshot.event_id).to eq(client.raw_event_stream.last[:id])
           end
 
-          it "should write-through-cache the event in a snapshot without duplicating events" do
+          it "writes through cache the event in a snapshot without duplicating events" do
             client.destroy!
             client.append([old_event, new_event, new_event])
             expected = []
@@ -302,7 +302,7 @@ describe EventStore::Client do
             expect(client.snapshot.to_a).to eq(expected)
           end
 
-          it "should raise a meaningful exception when a nil event given to it to append" do
+          it "raises a meaningful exception when a nil event given to it to append" do
             expect {client.append([nil])}.to raise_exception(ArgumentError)
           end
         end
@@ -312,12 +312,12 @@ describe EventStore::Client do
             client.append([old_event])
           end
 
-          it "should not raise an error when two events of the same type are appended" do
+          it "does not raise an error when two events of the same type are appended" do
             client.append([duplicate_event])
             client.append([duplicate_event]) #will fail automatically if it throws an error, no need for assertions (which now print warning for some reason)
           end
 
-          it "should write-through-cache the event in a snapshot without duplicating events" do
+          it "writes-through-cache the event in a snapshot without duplicating events" do
             client.destroy!
             client.append([old_event, new_event, new_event])
             expected = []
@@ -341,7 +341,7 @@ describe EventStore::Client do
           @bad_event.fully_qualified_name = nil
         end
 
-        it "should revert all append events if one fails" do
+        it "reverts all append events if one fails" do
           starting_count = client.count
           expect { client.append([new_event, @bad_event]) }.to raise_error(EventStore::AttributeMissingError)
           expect(client.count).to eq(starting_count)
@@ -353,13 +353,13 @@ describe EventStore::Client do
           expect(x).to eq(0)
         end
 
-        it "yield to the block after event creation" do
+        it "yields to the block after event creation" do
           x = 0
           client.append([]) { x += 1 }
           expect(x).to eq(1)
         end
 
-        it "should pass the raw event_data to the block" do
+        it "passes the raw event_data to the block" do
           client.append([new_event]) do |raw_event_data|
             expect(raw_event_data).to eq([new_event])
           end

--- a/spec/event_store/event_store_spec.rb
+++ b/spec/event_store/event_store_spec.rb
@@ -14,9 +14,10 @@ describe EventStore do
 
     context "with partitioning defined" do
       let(:expected) { "es_test.test_events_1955_01_31" }
-      let(:part_config) { { "table_name_suffix" => "_%Y_%m_%d", "partitioning" => true } }
+      let(:part_config) { { "schema" => "es_test", "table_name_suffix" => "_%Y_%m_%d", "partitioning" => true } }
 
-      before { allow(subject).to receive(:raw_db_config).and_return(part_config) }
+      before { subject.custom_config(part_config, subject.local_redis_config, "test_events", "test") }
+      after  { subject.custom_config(subject.raw_db_config["test"]["postgres"], subject.local_redis_config, "test_events", "test") }
 
       it "returns a properly formatted table name" do
         expect(subject.insert_table_name(date)).to eq(expected)

--- a/spec/event_store/event_store_spec.rb
+++ b/spec/event_store/event_store_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe EventStore do
+  describe ".insert_table_name" do
+    let(:date) { Date.parse("1955-01-31") }
+
+    context "without partitioning defined" do
+      let(:expected) { "es_test.test_events" }
+
+      it "returns a properly formatted default table name" do
+        expect(subject.insert_table_name(date)).to eq(expected)
+      end
+    end
+
+    context "with partitioning defined" do
+      let(:expected) { "es_test.test_events_1955_01_31" }
+      let(:part_config) { { "table_name_suffix" => "_%Y_%m_%d", "partitioning" => true } }
+
+      before { allow(subject).to receive(:raw_db_config).and_return(part_config) }
+
+      it "returns a properly formatted table name" do
+        expect(subject.insert_table_name(date)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/event_store/event_store_spec.rb
+++ b/spec/event_store/event_store_spec.rb
@@ -13,10 +13,10 @@ describe EventStore do
     end
 
     context "with partitioning defined" do
-      let(:expected) { "es_test.test_events_1955_01_31" }
-      let(:part_config) { { "schema" => "es_test", "table_name_suffix" => "_%Y_%m_%d", "partitioning" => true } }
+      let(:expected)         { "es_test.test_events_1955_01_31" }
+      let(:partition_config) { { "schema" => "es_test", "partition_name_suffix" => "_%Y_%m_%d", "partitioning" => true } }
 
-      before { subject.custom_config(part_config, subject.local_redis_config, "test_events", "test") }
+      before { subject.custom_config(partition_config, subject.local_redis_config, "test_events", "test") }
       after  { subject.custom_config(subject.raw_db_config["test"]["postgres"], subject.local_redis_config, "test_events", "test") }
 
       it "returns a properly formatted table name" do


### PR DESCRIPTION
* turn partitioning on and event_store will insert into 
  the partition for today
* naming convention is `table_name` + table_name_suffix
* all reads still come from the base table
* this only really works for postgres event stores
* vertica does not need this