### PR TITLE
Add support for multiple checkpoint events in case we're dealing with an unknown device type

### DIFF
--- a/lib/event_store/aggregate.rb
+++ b/lib/event_store/aggregate.rb
@@ -4,7 +4,7 @@ module EventStore
   class Aggregate
     extend Forwardable
 
-    attr_reader :id, :type, :event_table, :snapshot, :event_stream, :checkpoint_event
+    attr_reader :id, :type, :event_table, :snapshot, :event_stream, :checkpoint_events
 
     def_delegators :snapshot,
       :last_event,
@@ -35,13 +35,13 @@ module EventStore
       EventStore.db.from(EventStore.fully_qualified_table).select(:aggregate_id).distinct.order(:aggregate_id).limit(limit, offset).all.map{|item| item[:aggregate_id]}
     end
 
-    def initialize(id, type = EventStore.table_name, checkpoint_event = nil)
+    def initialize(id, type = EventStore.table_name, checkpoint_events = [])
       @id = id
       @type = type
 
-      @checkpoint_event = checkpoint_event
-      @snapshot         = Snapshot.new(self)
-      @event_stream     = EventStream.new(self)
+      @checkpoint_events = checkpoint_events
+      @snapshot          = Snapshot.new(self)
+      @event_stream      = EventStream.new(self)
     end
 
     def append(events, logger)

--- a/lib/event_store/client.rb
+++ b/lib/event_store/client.rb
@@ -22,8 +22,9 @@ module EventStore
       Aggregate.ids(offset, limit)
     end
 
-    def initialize(aggregate_id, aggregate_type = EventStore.table_name, checkpoint_event = nil)
-      @aggregate = Aggregate.new(aggregate_id, aggregate_type, checkpoint_event)
+    def initialize(aggregate_id, aggregate_type = EventStore.table_name, checkpoint_events = [])
+      checkpoint_events = [checkpoint_events].flatten
+      @aggregate = Aggregate.new(aggregate_id, aggregate_type, checkpoint_events)
     end
 
     def exists?

--- a/lib/event_store/event_stream.rb
+++ b/lib/event_store/event_stream.rb
@@ -67,10 +67,11 @@ module EventStore
       last_checkpoint = nil
 
       if checkpoint_events
-        checkpoint_events.each do |checkpoint_event|
-          last_checkpoint = last_event_before(Time.now.utc, [checkpoint_event]).first
-          break if last_checkpoint
+        checkpoints = last_event_before(Time.now.utc, checkpoint_events)
+        if checkpoints.map { |e| e[:fully_qualified_name] }.uniq.length > 1
+          raise "unexpected multiple checkpoint event types"
         end
+        last_checkpoint = checkpoints.last
       end
 
       if last_checkpoint

--- a/lib/event_store/event_stream.rb
+++ b/lib/event_store/event_stream.rb
@@ -2,12 +2,12 @@ module EventStore
   class EventStream
     include Enumerable
 
-    attr_reader :event_table, :checkpoint_event
+    attr_reader :event_table, :checkpoint_events
 
     def initialize aggregate
       @aggregate = aggregate
       @id = @aggregate.id
-      @checkpoint_event = aggregate.checkpoint_event
+      @checkpoint_events = aggregate.checkpoint_events
       @event_table_alias = "events"
       @event_table = "#{EventStore.schema}__#{EventStore.table_name}".to_sym
       @aliased_event_table = "#{event_table}___#{@event_table_alias}".to_sym
@@ -64,7 +64,14 @@ module EventStore
     end
 
     def snapshot_events
-      last_checkpoint = last_event_before(Time.now.utc, [checkpoint_event]).first if checkpoint_event
+      last_checkpoint = nil
+
+      if checkpoint_events
+        checkpoint_events.each do |checkpoint_event|
+          last_checkpoint = last_event_before(Time.now.utc, [checkpoint_event]).first
+          break if last_checkpoint
+        end
+      end
 
       if last_checkpoint
         events.where{ events__id >= last_checkpoint[:id].to_i }

--- a/spec/event_store/event_stream_spec.rb
+++ b/spec/event_store/event_stream_spec.rb
@@ -32,9 +32,9 @@ module EventStore
     end
 
     describe "#snapshot_events" do
-      let(:snapshot_events) { event_stream.snapshot_events }
-
       it "returns events since the last of one of multiple checkpoint events" do
+        snapshot_events = event_stream.snapshot_events
+
         expect(snapshot_events.count).to eql(3)
 
         expect(
@@ -48,6 +48,21 @@ module EventStore
         expect(
           snapshot_events.find { |event| event[:fully_qualified_name] == 'after_checkpoint_2' }
         ).not_to be_nil
+      end
+
+      it "raises an exception if multiple event types are returned" do
+        event = EventStore::Event.new(aggregate_id,
+                                      (event_time - 1000).utc,
+                                      "checkpoint_event_1",
+                                      "zone",
+                                      "#{1001.to_s(2)}_foo")
+
+        event_stream.append [event], logger
+
+        expect { event_stream.snapshot_events }.to raise_error do |error|
+          expect(error).to be_a(RuntimeError)
+          expect(error.message).to eql("unexpected multiple checkpoint event types")
+        end
       end
     end
   end

--- a/spec/event_store/event_stream_spec.rb
+++ b/spec/event_store/event_stream_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+
+module EventStore
+  describe EventStream do
+    let(:aggregate_id) { SecureRandom.uuid }
+    let(:checkpoint_events) {
+      %w[ checkpoint_event_1 checkpoint_event_2 ]
+    }
+    let(:aggregate) {
+      Aggregate.new(
+        aggregate_id,
+        EventStore.table_name,
+        checkpoint_events
+      )
+    }
+
+    let(:event_time) { Time.parse("2001-01-01 00:00:00 UTC") }
+
+    let(:events) {
+      [EventStore::Event.new(aggregate_id, (event_time - 2000).utc, "old_event", "zone", "#{1000.to_s(2)}_foo"),
+       EventStore::Event.new(aggregate_id, (event_time - 1000).utc, "checkpoint_event_2", "zone", "#{1001.to_s(2)}_foo"),
+       EventStore::Event.new(aggregate_id, (event_time + 100).utc,  "after_checkpoint_1", "zone", "#{1002.to_s(2)}_foo"),
+       EventStore::Event.new(aggregate_id, (event_time).utc,        "after_checkpoint_2", "zone", "#{12.to_s(2)}_foo")]
+    }
+
+    subject(:event_stream) { EventStream.new aggregate }
+
+    let(:logger) { Logger.new("/dev/null") }
+
+    before(:each) do
+      event_stream.append events, logger
+    end
+
+    describe "#snapshot_events" do
+      let(:snapshot_events) { event_stream.snapshot_events }
+
+      it "returns events since the last of one of multiple checkpoint events" do
+        expect(snapshot_events.count).to eql(3)
+
+        expect(
+          snapshot_events.find { |event| event[:fully_qualified_name] == 'checkpoint_event_2' }
+        ).not_to be_nil
+
+        expect(
+          snapshot_events.find { |event| event[:fully_qualified_name] == 'after_checkpoint_1' }
+        ).not_to be_nil
+
+        expect(
+          snapshot_events.find { |event| event[:fully_qualified_name] == 'after_checkpoint_2' }
+        ).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/snapshot_unit_spec.rb
+++ b/spec/unit/snapshot_unit_spec.rb
@@ -14,7 +14,7 @@ module EventStore
              type: aggregate_type,
              id: aggregate_id,
              events: double(all: events),
-             checkpoint_event: checkpoint_event,
+             checkpoint_events: [checkpoint_event],
              snapshot_events: double(all: snapshot_events))
     }
 


### PR DESCRIPTION
This allows consumers to request snapshots for more than one device type.  Since consumers may infer the device type based on the returned events, it has no knowledge of the device type when requesting a snapshot, and since different device types have different snapshot events, this is problematic. This allows the faceplate to request a snapshot and pass an array of event names (all known snapshot events) so the event store can return a snapshot since the first one it finds.  In practice, because each device will only have one snapshot event type, we will get our desired outcome