### PR TITLE
[#149611315] Shard redis snapshot servers

### DIFF
--- a/lib/event_store/snapshot.rb
+++ b/lib/event_store/snapshot.rb
@@ -8,7 +8,7 @@ module EventStore
 
     def initialize aggregate
       @aggregate = aggregate
-      @redis = EventStore.redis
+      @redis = EventStore.redis(aggregate.id)
       @snapshot_table = "#{@aggregate.type}_snapshots_for_#{@aggregate.id}"
       @snapshot_event_id_table = "#{@aggregate.type}_snapshot_event_ids_for_#{@aggregate.id}"
     end
@@ -65,7 +65,7 @@ module EventStore
     end
 
     def delete_snapshot!
-      EventStore.redis.del [snapshot_table, snapshot_event_id_table]
+      @redis.del [snapshot_table, snapshot_event_id_table]
     end
 
     def store_snapshot(prepared_events, logger=default_logger)

--- a/spec/event_store/client_spec.rb
+++ b/spec/event_store/client_spec.rb
@@ -56,7 +56,7 @@ describe EventStore::Client do
       end
 
       it "should be empty for aggregates without events" do
-        stream = es_client.new(100, :device).raw_event_stream
+        stream = es_client.new("100", :device).raw_event_stream
         expect(stream.empty?).to be_truthy
       end
 
@@ -80,7 +80,7 @@ describe EventStore::Client do
       end
 
       it "should be empty for aggregates without events" do
-        stream = es_client.new(100, :device).raw_event_stream
+        stream = es_client.new("100", :device).raw_event_stream
         expect(stream.empty?).to be_truthy
       end
 
@@ -115,6 +115,7 @@ describe EventStore::Client do
         end
       end
     end
+
 
     describe "#raw_event_streams_from_event_id" do
       subject { es_client.new(AGGREGATE_ID_ONE, :device) }

--- a/spec/event_store/snapshot_spec.rb
+++ b/spec/event_store/snapshot_spec.rb
@@ -6,13 +6,15 @@ AGGREGATE_ID_TWO = SecureRandom.uuid
 
 module EventStore
   describe "Snapshots" do
+    let(:redis)  { EventStore.redis("") }
+
     context "when there are no events" do
-      let(:client)    { EventStore::Client.new(AGGREGATE_ID_ONE) }
+      let(:client) { EventStore::Client.new(AGGREGATE_ID_ONE) }
 
       it "should build an empty snapshot for a new client" do
         expect(client.snapshot.any?).to eq(false)
         expect(client.event_id).to eq(-1)
-        expect(EventStore.redis.hget(client.snapshot_event_id_table, :current_event_id)).to eq(nil)
+        expect(redis.hget(client.snapshot_event_id_table, :current_event_id)).to eq(nil)
       end
 
       it "a client should rebuild a snapshot" do
@@ -104,8 +106,8 @@ module EventStore
           before(:each) { snapshot.reject! { true } }
 
           it "deletes the snapshot out of Redis" do
-            expect(EventStore.redis.keys(snapshot.snapshot_table).length).to eq(0)
-            expect(EventStore.redis.keys(snapshot.snapshot_event_id_table).length).to eq(0)
+            expect(redis.keys(snapshot.snapshot_table).length).to eq(0)
+            expect(redis.keys(snapshot.snapshot_event_id_table).length).to eq(0)
           end
         end
       end

--- a/spec/unit/snapshot_unit_spec.rb
+++ b/spec/unit/snapshot_unit_spec.rb
@@ -3,7 +3,7 @@ require "mock_redis"
 
 module EventStore
   describe Snapshot do
-    let(:redis)            { EventStore.redis }
+    let(:redis)            { EventStore.redis("") } # there's only one in test env anyway
     let(:aggregate_type)   { "awesome" }
     let(:aggregate_id)     { "superman" }
     let(:events)           { [] }


### PR DESCRIPTION
* If the redis config contains only { host: "some_host" }, then all is
  the same as it is now.
* If the redis config contains { hosts: ["host1", "host2"] }, when we
  find the snapshot for an aggregate, we will CRC32 its id and use that as
  an index into the list of redises.