### PR TITLE
Drop single-column indices from event store to keep the critical index hot

### DIFF
--- a/db/pg_migrations/005_drop_excess_indices_from_event_store.rb
+++ b/db/pg_migrations/005_drop_excess_indices_from_event_store.rb
@@ -1,0 +1,22 @@
+require 'event_store'
+Sequel.migration do
+  no_transaction
+
+  event_store_table = Sequel.qualify(EventStore.schema, EventStore.table_name)
+
+  up do
+    alter_table(event_store_table) do
+      drop_index :aggregate_id
+      drop_index :occurred_at
+      drop_index :version
+    end
+  end
+
+  down do
+    alter_table(event_store_table) do
+      add_index :version
+      add_index :occurred_at
+      add_index :aggregate_id
+    end
+  end
+end


### PR DESCRIPTION
The index on the event store that matters for real queries is the one that indexes by the `(aggregate_id, occurred_at, fully_qualified_name_id)` tuple.  That's because the kind of queries that we need to be able to answer quickly look like:
```
2018-12-27 14:20:12 UTC:10.3.0.163(41378):nexia@history_store:[7054]:LOG: duration: 1183.411 ms statement: SELECT "events".*, "fully_qualified_name" FROM "event_store"."thermostat_events" AS "events" INNER JOIN event_store.fully_qualified_names ON (event_store.fully_qualified_names."id" = "events"."fully_qualified_name_id") WHERE (("aggregate_id" = '01532BF8') AND ("occurred_at" >= '2018-12-20 05:00:00.000000+0000') AND ("occurred_at" <= '2018-12-27 14:20:07.000000+0000') AND ("fully_qualified_name" IN ('faceplate_api.thermostats.capabilities.alarms.AlarmSnapshotTaken', 'faceplate_api.thermostats.capabilities.alarms.SystemAlarmAdded', 'faceplate_api.thermostats.capabilities.alarms.SystemAlarmRemoved', 'faceplate_api.thermostats.capabilities.alarms.ZoneAlarmAdded', 'faceplate_api.thermostats.capabilities.alarms.ZoneAlarmRemoved', 'faceplate_api.devices.core.events.DeviceRestarted'))) ORDER BY "events"."id"
```
Single-column indices (other than the one on the primary key `id`) don't add value.  They're infrequently queried, so they're not hot in RAM; and accessing them for queries like `SELECT count(*) ... WHERE ("aggregate_id" = '0151809C')` doesn't bring the index that's really needed into RAM, so I/O spent loading them is wasted.  Mostly they just waste space and slow down INSERTs.  So this change just drops them.
